### PR TITLE
Added surface and surfaceContainer to showContextMenu() to customize the backgrounds.

### DIFF
--- a/example/lib/entries/custom_context_menu_item.dart
+++ b/example/lib/entries/custom_context_menu_item.dart
@@ -26,7 +26,8 @@ final class CustomContextMenuItem extends ContextMenuItem<String> {
 
   @override
   Widget builder(BuildContext context, ContextMenuState menuState,
-      Color? surface, Color? surfaceContainer, [FocusNode? focusNode]) {
+      Color? surface, Color? surfaceContainer,
+      [FocusNode? focusNode]) {
     return ListTile(
       focusNode: focusNode, // important for highlighting item on focus
       title: SizedBox(width: double.maxFinite, child: Text(label)),

--- a/example/lib/entries/custom_context_menu_item.dart
+++ b/example/lib/entries/custom_context_menu_item.dart
@@ -26,7 +26,7 @@ final class CustomContextMenuItem extends ContextMenuItem<String> {
 
   @override
   Widget builder(BuildContext context, ContextMenuState menuState,
-      [FocusNode? focusNode]) {
+      Color? surface, Color? surfaceContainer, [FocusNode? focusNode]) {
     return ListTile(
       focusNode: focusNode, // important for highlighting item on focus
       title: SizedBox(width: double.maxFinite, child: Text(label)),

--- a/lib/src/components/menu_divider.dart
+++ b/lib/src/components/menu_divider.dart
@@ -40,7 +40,8 @@ final class MenuDivider extends ContextMenuEntry<Never> {
         assert(endIndent == null || endIndent >= 0.0);
 
   @override
-  Widget builder(BuildContext context, ContextMenuState menuState) {
+  Widget builder(BuildContext context, ContextMenuState menuState,
+      Color? surface, Color? surfaceContainer) {
     return Divider(
       height: height ?? 8.0,
       thickness: thickness ?? 0.0,

--- a/lib/src/components/menu_header.dart
+++ b/lib/src/components/menu_header.dart
@@ -28,7 +28,8 @@ final class MenuHeader extends ContextMenuEntry<Never> {
   });
 
   @override
-  Widget builder(BuildContext context, ContextMenuState menuState) {
+  Widget builder(BuildContext context, ContextMenuState menuState,
+      Color? surface, Color? surfaceContainer) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
       child: Align(

--- a/lib/src/components/menu_item.dart
+++ b/lib/src/components/menu_item.dart
@@ -60,11 +60,13 @@ final class MenuItem<T> extends ContextMenuItem<T> {
 
   @override
   Widget builder(BuildContext context, ContextMenuState menuState,
-      Color? surface, Color? surfaceContainer, [FocusNode? focusNode]) {
+      Color? surface, Color? surfaceContainer,
+      [FocusNode? focusNode]) {
     bool isFocused = menuState.focusedEntry == this;
 
     final background = surface ?? context.colorScheme.surface;
-    final focusedBackground = surfaceContainer ?? context.colorScheme.surfaceContainer;
+    final focusedBackground =
+        surfaceContainer ?? context.colorScheme.surfaceContainer;
     final normalTextColor = Color.alphaBlend(
       (color ?? context.colorScheme.onSurface).withValues(alpha: 0.7),
       background,

--- a/lib/src/components/menu_item.dart
+++ b/lib/src/components/menu_item.dart
@@ -60,11 +60,11 @@ final class MenuItem<T> extends ContextMenuItem<T> {
 
   @override
   Widget builder(BuildContext context, ContextMenuState menuState,
-      [FocusNode? focusNode]) {
+      Color? surface, Color? surfaceContainer, [FocusNode? focusNode]) {
     bool isFocused = menuState.focusedEntry == this;
 
-    final background = context.colorScheme.surface;
-    final focusedBackground = context.colorScheme.surfaceContainer;
+    final background = surface ?? context.colorScheme.surface;
+    final focusedBackground = surfaceContainer ?? context.colorScheme.surfaceContainer;
     final normalTextColor = Color.alphaBlend(
       (color ?? context.colorScheme.onSurface).withValues(alpha: 0.7),
       background,

--- a/lib/src/core/models/context_menu_entry.dart
+++ b/lib/src/core/models/context_menu_entry.dart
@@ -18,7 +18,8 @@ abstract base class ContextMenuEntry<T> {
   ///
   /// - [context] - The context of the widget.
   /// - [menuState] - The state of the current context menu.
-  Widget builder(BuildContext context, ContextMenuState menuState);
+  Widget builder(BuildContext context, ContextMenuState menuState,
+      Color? surface, Color? surfaceContainer);
 
   /// Called when the mouse pointer enters the area of the context menu entry.
   void onMouseEnter(PointerEnterEvent event, ContextMenuState menuState) {}

--- a/lib/src/core/models/context_menu_item.dart
+++ b/lib/src/core/models/context_menu_item.dart
@@ -94,5 +94,5 @@ abstract base class ContextMenuItem<T> extends ContextMenuEntry<T> {
 
   @override
   Widget builder(BuildContext context, ContextMenuState menuState,
-      [FocusNode focusNode]);
+      Color? surface, Color? surfaceContainer, [FocusNode focusNode]);
 }

--- a/lib/src/core/models/context_menu_item.dart
+++ b/lib/src/core/models/context_menu_item.dart
@@ -94,5 +94,6 @@ abstract base class ContextMenuItem<T> extends ContextMenuEntry<T> {
 
   @override
   Widget builder(BuildContext context, ContextMenuState menuState,
-      Color? surface, Color? surfaceContainer, [FocusNode focusNode]);
+      Color? surface, Color? surfaceContainer,
+      [FocusNode focusNode]);
 }

--- a/lib/src/core/utils/helpers.dart
+++ b/lib/src/core/utils/helpers.dart
@@ -9,7 +9,8 @@ import 'menu_route_options.dart';
 Future<T?> showContextMenu<T>(
   BuildContext context, {
   required ContextMenu<T> contextMenu,
-  Color? surfaceColor,
+  Color? surface,
+  Color? surfaceContainer,
   MenuRouteOptions? routeOptions,
 }) async {
   final menuState = ContextMenuState(menu: contextMenu);
@@ -21,7 +22,8 @@ Future<T?> showContextMenu<T>(
     PageRouteBuilder<T>(
       pageBuilder: (context, animation, secondaryAnimation) {
         return Stack(
-          children: [ContextMenuWidget(menuState: menuState, surfaceColor: surfaceColor)],
+          children: [ContextMenuWidget(menuState: menuState,
+              surface: surface, surfaceContainer: surfaceContainer)],
         );
       },
       fullscreenDialog: true,

--- a/lib/src/core/utils/helpers.dart
+++ b/lib/src/core/utils/helpers.dart
@@ -9,6 +9,7 @@ import 'menu_route_options.dart';
 Future<T?> showContextMenu<T>(
   BuildContext context, {
   required ContextMenu<T> contextMenu,
+  Color? surfaceColor,
   MenuRouteOptions? routeOptions,
 }) async {
   final menuState = ContextMenuState(menu: contextMenu);
@@ -20,7 +21,7 @@ Future<T?> showContextMenu<T>(
     PageRouteBuilder<T>(
       pageBuilder: (context, animation, secondaryAnimation) {
         return Stack(
-          children: [ContextMenuWidget(menuState: menuState)],
+          children: [ContextMenuWidget(menuState: menuState, surfaceColor: surfaceColor)],
         );
       },
       fullscreenDialog: true,

--- a/lib/src/core/utils/helpers.dart
+++ b/lib/src/core/utils/helpers.dart
@@ -22,8 +22,12 @@ Future<T?> showContextMenu<T>(
     PageRouteBuilder<T>(
       pageBuilder: (context, animation, secondaryAnimation) {
         return Stack(
-          children: [ContextMenuWidget(menuState: menuState,
-              surface: surface, surfaceContainer: surfaceContainer)],
+          children: [
+            ContextMenuWidget(
+                menuState: menuState,
+                surface: surface,
+                surfaceContainer: surfaceContainer)
+          ],
         );
       },
       fullscreenDialog: true,

--- a/lib/src/widgets/context_menu_widget.dart
+++ b/lib/src/widgets/context_menu_widget.dart
@@ -14,10 +14,12 @@ import 'menu_entry_widget.dart';
 
 class ContextMenuWidget extends StatelessWidget {
   final ContextMenuState menuState;
-  final Color? surfaceColor;
+  final Color? surface;
+  final Color? surfaceContainer;
   const ContextMenuWidget({
     required this.menuState,
-    this.surfaceColor,
+    this.surface,
+    this.surfaceContainer,
     super.key,
   });
 
@@ -45,7 +47,7 @@ class ContextMenuWidget extends StatelessWidget {
                   node: state.focusScopeNode,
                   child: Opacity(
                     opacity: state.isPositionVerified ? 1.0 : 0.0,
-                    child: _buildMenuView(context, state, surfaceColor),
+                    child: _buildMenuView(context, state, surface, surfaceContainer),
                   ),
                 ),
               ),
@@ -57,14 +59,15 @@ class ContextMenuWidget extends StatelessWidget {
   }
 
   /// Builds the context menu view.
-  Widget _buildMenuView(BuildContext context, ContextMenuState state, Color? surfaceColor) {
+  Widget _buildMenuView(BuildContext context, ContextMenuState state,
+      Color? surface, Color? surfaceContainer) {
     // final parentItem = state.parentItem;
     // if (parentItem?.isSubmenuItem == true) {
     //   print(parentItem?.debugLabel);
     // }
 
     var boxDecoration = BoxDecoration(
-      color: surfaceColor ?? Theme.of(context).colorScheme.surface,
+      color: surface ?? Theme.of(context).colorScheme.surface,
       boxShadow: [
         BoxShadow(
           color: Theme.of(context).shadowColor.withValues(alpha: 0.5),
@@ -99,7 +102,7 @@ class ContextMenuWidget extends StatelessWidget {
                 child: Column(
                   children: [
                     for (final item in state.entries)
-                      MenuEntryWidget(entry: item)
+                      MenuEntryWidget(entry: item, surface: surface, surfaceContainer: surfaceContainer)
                   ],
                 ),
               ),

--- a/lib/src/widgets/context_menu_widget.dart
+++ b/lib/src/widgets/context_menu_widget.dart
@@ -47,7 +47,8 @@ class ContextMenuWidget extends StatelessWidget {
                   node: state.focusScopeNode,
                   child: Opacity(
                     opacity: state.isPositionVerified ? 1.0 : 0.0,
-                    child: _buildMenuView(context, state, surface, surfaceContainer),
+                    child: _buildMenuView(
+                        context, state, surface, surfaceContainer),
                   ),
                 ),
               ),
@@ -102,7 +103,10 @@ class ContextMenuWidget extends StatelessWidget {
                 child: Column(
                   children: [
                     for (final item in state.entries)
-                      MenuEntryWidget(entry: item, surface: surface, surfaceContainer: surfaceContainer)
+                      MenuEntryWidget(
+                          entry: item,
+                          surface: surface,
+                          surfaceContainer: surfaceContainer)
                   ],
                 ),
               ),

--- a/lib/src/widgets/context_menu_widget.dart
+++ b/lib/src/widgets/context_menu_widget.dart
@@ -14,9 +14,11 @@ import 'menu_entry_widget.dart';
 
 class ContextMenuWidget extends StatelessWidget {
   final ContextMenuState menuState;
+  final Color? surfaceColor;
   const ContextMenuWidget({
-    super.key,
     required this.menuState,
+    this.surfaceColor,
+    super.key,
   });
 
   @override
@@ -43,7 +45,7 @@ class ContextMenuWidget extends StatelessWidget {
                   node: state.focusScopeNode,
                   child: Opacity(
                     opacity: state.isPositionVerified ? 1.0 : 0.0,
-                    child: _buildMenuView(context, state),
+                    child: _buildMenuView(context, state, surfaceColor),
                   ),
                 ),
               ),
@@ -55,14 +57,14 @@ class ContextMenuWidget extends StatelessWidget {
   }
 
   /// Builds the context menu view.
-  Widget _buildMenuView(BuildContext context, ContextMenuState state) {
+  Widget _buildMenuView(BuildContext context, ContextMenuState state, Color? surfaceColor) {
     // final parentItem = state.parentItem;
     // if (parentItem?.isSubmenuItem == true) {
     //   print(parentItem?.debugLabel);
     // }
 
     var boxDecoration = BoxDecoration(
-      color: Theme.of(context).colorScheme.surface,
+      color: surfaceColor ?? Theme.of(context).colorScheme.surface,
       boxShadow: [
         BoxShadow(
           color: Theme.of(context).shadowColor.withValues(alpha: 0.5),

--- a/lib/src/widgets/menu_entry_widget.dart
+++ b/lib/src/widgets/menu_entry_widget.dart
@@ -64,11 +64,13 @@ class _MenuEntryWidgetState<T> extends State<MenuEntryWidget<T>> {
                     _ensureFocused(item, menuState, focusNode);
                   }
                 },
-                child: item.builder(context, menuState, widget.surface, widget.surfaceContainer, focusNode),
+                child: item.builder(context, menuState, widget.surface,
+                    widget.surfaceContainer, focusNode),
               ),
             );
           } else {
-            return entry.builder(context, menuState, widget.surface, widget.surfaceContainer);
+            return entry.builder(
+                context, menuState, widget.surface, widget.surfaceContainer);
           }
         },
       ),

--- a/lib/src/widgets/menu_entry_widget.dart
+++ b/lib/src/widgets/menu_entry_widget.dart
@@ -11,7 +11,14 @@ import 'context_menu_state.dart';
 /// This widget is used internally by the `ContextMenu` contextMenu.
 class MenuEntryWidget<T> extends StatefulWidget {
   final ContextMenuEntry<T> entry;
-  const MenuEntryWidget({super.key, required this.entry});
+  final Color? surface;
+  final Color? surfaceContainer;
+  const MenuEntryWidget({
+    required this.entry,
+    this.surface,
+    this.surfaceContainer,
+    super.key,
+  });
 
   @override
   State<MenuEntryWidget<T>> createState() => _MenuEntryWidgetState<T>();
@@ -57,11 +64,11 @@ class _MenuEntryWidgetState<T> extends State<MenuEntryWidget<T>> {
                     _ensureFocused(item, menuState, focusNode);
                   }
                 },
-                child: item.builder(context, menuState, focusNode),
+                child: item.builder(context, menuState, widget.surface, widget.surfaceContainer, focusNode),
               ),
             );
           } else {
-            return entry.builder(context, menuState);
+            return entry.builder(context, menuState, widget.surface, widget.surfaceContainer);
           }
         },
       ),


### PR DESCRIPTION
When using showContextMenu() there was no way (i.e. I didn't find any) to override the app's theme's surface and surfaceContainer which are used for drawing the menu items.