### PR TITLE
feat: Make context menu scrollable for long Menu items

### DIFF
--- a/example/lib/pages/demo_page.dart
+++ b/example/lib/pages/demo_page.dart
@@ -2,7 +2,7 @@ import 'package:example/pages/menu_items.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_context_menu/flutter_context_menu.dart';
 
-Map<String, ContextMenu> _contextMenus() => {
+Map<String, ContextMenu> _contextMenus(BuildContext context) => {
       "Default (built-in)": ContextMenu(entries: defaultContextMenuItems),
       "Custom\n\nmax width: 200\npadding: 0": ContextMenu(
         entries: customContextMenuItems,
@@ -27,7 +27,10 @@ Map<String, ContextMenu> _contextMenus() => {
         entries: defaultContextMenuItems,
         padding: EdgeInsets.zero,
         position: const Offset(50, 30),
-      )
+      ),
+      "Long Menu": ContextMenu(
+        entries: getLongContextMenuItems(context),
+      ),
     };
 
 class DemoPage extends StatelessWidget {
@@ -35,6 +38,8 @@ class DemoPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final menus = _contextMenus(context);
+
     return Scaffold(
       appBar: AppBar(
         // backgroundColor: Theme.of(context).colorScheme.inversePrimary,
@@ -45,16 +50,17 @@ class DemoPage extends StatelessWidget {
           crossAxisCount: 2,
           childAspectRatio: 16 / 9,
         ),
-        itemCount: 4,
+        itemCount: menus.length,
         itemBuilder: (context, index) {
           final colors = [
             const Color(0xFF17202a),
             const Color(0xFF1c2833),
             const Color(0xFF212f3d),
             const Color(0xFF273746),
+            const Color(0xFF2c3e50),
           ];
           final color = colors[index % colors.length];
-          final entry = _contextMenus().entries.toList()[index];
+          final entry = menus.entries.toList()[index];
           final text = entry.key;
           final menu = entry.value;
 

--- a/example/lib/pages/menu_items.dart
+++ b/example/lib/pages/menu_items.dart
@@ -177,3 +177,35 @@ const customContextMenuItems = <ContextMenuEntry>[
     ],
   ),
 ];
+
+List<ContextMenuEntry> getLongContextMenuItems(BuildContext context) {
+  final screenSize = MediaQuery.of(context).size;
+  const itemHeight = 32.0;
+  final itemsCount = (screenSize.height / itemHeight).floor() * 1.5;
+  final items = <ContextMenuEntry>[];
+
+  for (int i = 1; i <= itemsCount; i++) {
+    items.add(MenuItem(
+      label: "Item $i",
+      value: "Item $i",
+      icon: i % 2 == 0 ? Icons.star_rounded : Icons.circle,
+      color: i % 3 == 0 ? Colors.blue : null,
+      enabled: i % 5 != 0,
+    ));
+  }
+  items.add(const MenuDivider());
+  items.add(MenuItem.submenu(
+    label: "More Options",
+    icon: Icons.more_horiz,
+    items: [
+      for (int j = 1; j <= 10; j++)
+        MenuItem(
+          label: "Option $j",
+          value: "Option $j",
+          icon: Icons.settings,
+        ),
+    ],
+  ));
+
+  return items;
+}

--- a/lib/src/core/models/context_menu.dart
+++ b/lib/src/core/models/context_menu.dart
@@ -25,6 +25,9 @@ class ContextMenu<T> {
   /// Defaults to 350.0
   double maxWidth;
 
+  /// The maximum height of the context menu.
+  double? maxHeight;
+
   /// The clip behavior of the context menu.
   ///
   /// Defaults to [Clip.antiAlias]
@@ -44,6 +47,7 @@ class ContextMenu<T> {
     EdgeInsets? padding,
     this.borderRadius,
     double? maxWidth,
+    this.maxHeight,
     Clip? clipBehavior,
     this.boxDecoration,
     Map<ShortcutActivator, VoidCallback>? shortcuts,
@@ -65,6 +69,7 @@ class ContextMenu<T> {
     EdgeInsets? padding,
     BorderRadiusGeometry? borderRadius,
     double? maxWidth,
+    double? maxHeight,
     Clip? clipBehavior,
     BoxDecoration? boxDecoration,
   }) {
@@ -74,6 +79,7 @@ class ContextMenu<T> {
       padding: padding ?? this.padding,
       borderRadius: borderRadius ?? this.borderRadius,
       maxWidth: maxWidth ?? this.maxWidth,
+      maxHeight: maxHeight ?? this.maxHeight,
       clipBehavior: clipBehavior ?? this.clipBehavior,
       boxDecoration: boxDecoration ?? this.boxDecoration,
     );

--- a/lib/src/core/utils/utils.dart
+++ b/lib/src/core/utils/utils.dart
@@ -5,6 +5,8 @@ import 'package:flutter/widgets.dart';
 import '../models/context_menu.dart';
 import '../utils/extensions.dart';
 
+const double kContextMenuSafeArea = 8.0;
+
 /// Calculates the position of the context menu based on the position of the
 /// menu and the position of the parent menu. To prevent the menu from
 /// extending beyond the screen boundaries.
@@ -16,7 +18,8 @@ import '../utils/extensions.dart';
   bool isSubmenu,
 ) {
   final screenSize = MediaQuery.of(context).size;
-  final safeScreenRect = (Offset.zero & screenSize).deflate(8.0);
+  final safeScreenRect =
+      (Offset.zero & screenSize).deflate(kContextMenuSafeArea);
   final menuRect = context.getWidgetBounds()!;
   AlignmentGeometry nextSpawnAlignment = spawnAlignment;
 

--- a/lib/src/widgets/context_menu_state.dart
+++ b/lib/src/widgets/context_menu_state.dart
@@ -72,6 +72,8 @@ class ContextMenuState extends ChangeNotifier {
 
   double get maxWidth => menu.maxWidth;
 
+  double? get maxHeight => menu.maxHeight;
+
   BorderRadiusGeometry? get borderRadius => menu.borderRadius;
 
   EdgeInsets get padding => menu.padding;

--- a/lib/src/widgets/context_menu_widget.dart
+++ b/lib/src/widgets/context_menu_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../core/utils/shortcuts/menu_shortcuts.dart';
+import '../core/utils/utils.dart';
 import 'context_menu_provider.dart';
 import 'context_menu_state.dart';
 import 'menu_entry_widget.dart';
@@ -14,6 +15,7 @@ import 'menu_entry_widget.dart';
 
 class ContextMenuWidget extends StatelessWidget {
   final ContextMenuState menuState;
+
   const ContextMenuWidget({
     super.key,
     required this.menuState,
@@ -88,7 +90,8 @@ class ContextMenuWidget extends StatelessWidget {
             padding: state.padding,
             constraints: BoxConstraints(
               maxWidth: state.maxWidth,
-              maxHeight: state.maxHeight ?? double.infinity,
+              maxHeight: MediaQuery.of(context).size.height -
+                  (kContextMenuSafeArea * 2),
             ),
             clipBehavior: state.clipBehavior,
             decoration: state.boxDecoration ?? boxDecoration,

--- a/lib/src/widgets/context_menu_widget.dart
+++ b/lib/src/widgets/context_menu_widget.dart
@@ -88,17 +88,21 @@ class ContextMenuWidget extends StatelessWidget {
             padding: state.padding,
             constraints: BoxConstraints(
               maxWidth: state.maxWidth,
+              maxHeight: state.maxHeight ?? double.infinity,
             ),
             clipBehavior: state.clipBehavior,
             decoration: state.boxDecoration ?? boxDecoration,
             child: Material(
               type: MaterialType.transparency,
               child: IntrinsicWidth(
-                child: Column(
-                  children: [
-                    for (final item in state.entries)
-                      MenuEntryWidget(entry: item)
-                  ],
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (final item in state.entries)
+                        MenuEntryWidget(entry: item)
+                    ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION

Fixes #14 

This pull request introduces scrolling functionality to the context menu, preventing overflow issues when the number of items exceeds the available screen space.

**Key Changes:**

*   **`lib/src/core/models/context_menu.dart`**:
    *   Added an optional `maxHeight` property to the `ContextMenu` model. This allows developers to explicitly set a maximum height for the menu.

*   **`lib/src/widgets/context_menu_widget.dart`**:
    *   Wrapped the menu's `Column` of items within a `SingleChildScrollView`.
    *   Applied a `maxHeight` constraint to the menu's container. If the content's height exceeds this value, the `SingleChildScrollView` enables vertical scrolling.

These changes ensure that even long context menus remain usable and fully accessible within the viewport.

**How to Test:**

You can test this functionality by creating a `ContextMenu` with a large number of entries and assigning a value to the new `maxHeight` property, like so:

```dart
final contextMenu = ContextMenu(
  // A long list of menu items
  entries: List.generate(
    50,
    (index) => MenuItem(label: 'Item ${index + 1}'),
  ),
  // Set a maximum height for the context menu
  maxHeight: 300,
);
```


__

Before, if you had 100 items in the context menu, it wouldn't be scrollable. You'd only see 10 or such. Now we are using a `SingleChildScrollView`


