### PR TITLE
Make `showContextMenu` use the root navigator by default

### DIFF
--- a/lib/src/core/utils/helpers.dart
+++ b/lib/src/core/utils/helpers.dart
@@ -10,13 +10,17 @@ Future<T?> showContextMenu<T>(
   BuildContext context, {
   required ContextMenu<T> contextMenu,
   MenuRouteOptions? routeOptions,
+  bool useRootNavigator = true,
 }) async {
   final menuState = ContextMenuState(menu: contextMenu);
   routeOptions ??= const MenuRouteOptions(
     barrierDismissible: true,
   );
-  return await Navigator.push<T>(
-    context,
+
+  // Use root navigator to make sure the context menu is always on top, and to
+  // fix the issue where the context menu may be opened for each navigator, and
+  // to make sure the context menu is opened once.
+  return await Navigator.of(context, rootNavigator: useRootNavigator).push<T>(
     PageRouteBuilder<T>(
       pageBuilder: (context, animation, secondaryAnimation) {
         return Stack(


### PR DESCRIPTION
This change modifies the `showContextMenu` function to use `Navigator.of(context, rootNavigator: true)` instead of `Navigator.push(context)`.

This ensures that the context menu is always displayed on top of all other content and prevents multiple context menus from being opened if nested navigators are present.

fixes #21