### PR TITLE
fix: prevent context menu from stealing focus on pointer-triggered open

### DIFF
--- a/lib/src/core/utils/helpers.dart
+++ b/lib/src/core/utils/helpers.dart
@@ -13,10 +13,16 @@ Future<T?> showContextMenu<T>(
   bool useRootNavigator = true,
   ValueChanged<T?>? onItemSelected,
 }) async {
-  final menuState =
-      ContextMenuState<T>(menu: contextMenu, onItemSelected: onItemSelected);
+  final menuState = ContextMenuState<T>(
+    menu: contextMenu,
+    onItemSelected: onItemSelected,
+    requestFocus: routeOptions?.requestFocus ?? true,
+  );
   routeOptions ??= const MenuRouteOptions(
     barrierDismissible: true,
+  );
+  routeOptions = routeOptions.copyWith(
+    requestFocus: routeOptions.requestFocus ?? true,
   );
 
   // Use root navigator to make sure the context menu is always on top, and to

--- a/lib/src/core/utils/menu_route_options.dart
+++ b/lib/src/core/utils/menu_route_options.dart
@@ -26,6 +26,35 @@ class MenuRouteOptions {
     this.maintainState = true,
     this.allowSnapshotting = true,
   });
+
+  MenuRouteOptions copyWith({
+    RouteSettings? routeSettings,
+    bool? requestFocus,
+    RouteTransitionsBuilder? transitionsBuilder,
+    Duration? transitionDuration,
+    Duration? reverseTransitionDuration,
+    bool? opaque,
+    bool? barrierDismissible,
+    Color? barrierColor,
+    String? barrierLabel,
+    bool? maintainState,
+    bool? allowSnapshotting,
+  }) {
+    return MenuRouteOptions(
+      routeSettings: routeSettings ?? this.routeSettings,
+      requestFocus: requestFocus ?? this.requestFocus,
+      transitionsBuilder: transitionsBuilder ?? this.transitionsBuilder,
+      transitionDuration: transitionDuration ?? this.transitionDuration,
+      reverseTransitionDuration:
+          reverseTransitionDuration ?? this.reverseTransitionDuration,
+      opaque: opaque ?? this.opaque,
+      barrierDismissible: barrierDismissible ?? this.barrierDismissible,
+      barrierColor: barrierColor ?? this.barrierColor,
+      barrierLabel: barrierLabel ?? this.barrierLabel,
+      maintainState: maintainState ?? this.maintainState,
+      allowSnapshotting: allowSnapshotting ?? this.allowSnapshotting,
+    );
+  }
 }
 
 Widget _defaultTransitionsBuilder(

--- a/lib/src/widgets/context_menu_region.dart
+++ b/lib/src/widgets/context_menu_region.dart
@@ -99,10 +99,12 @@ class _ContextMenuRegionState<T> extends State<ContextMenuRegion<T>> {
   void _showMenu(BuildContext context, Offset position) {
     final menu = widget.contextMenu
         .copyWith(position: widget.contextMenu.position ?? position);
+    final routeOptions = (widget.routeOptions ?? const MenuRouteOptions())
+        .copyWith(requestFocus: widget.routeOptions?.requestFocus ?? false);
     showContextMenu<T>(
       context,
       contextMenu: menu,
-      routeOptions: widget.routeOptions,
+      routeOptions: routeOptions,
       onItemSelected: widget.onItemSelected,
     );
   }

--- a/lib/src/widgets/context_menu_state.dart
+++ b/lib/src/widgets/context_menu_state.dart
@@ -49,13 +49,25 @@ class ContextMenuState<T> extends ChangeNotifier {
 
   final ValueChanged<T?>? onItemSelected;
 
+  /// Whether the context menu should request focus when opened.
+  ///
+  /// When `false`, the menu will not steal focus from the currently focused
+  /// widget (e.g. a text field with selected text). This is the default
+  /// behavior when the menu is opened via pointer events (right-click or
+  /// long press) through [ContextMenuRegion].
+  final bool _requestFocus;
+
+  bool get requestFocus => _requestFocus;
+
   ContextMenuState({
     required this.menu,
     this.parentItem,
     this.onItemSelected,
+    bool requestFocus = true,
   })  : _parentItemRect = null,
         _isSubmenu = false,
         selfClose = null,
+        _requestFocus = requestFocus,
         _spawnAnchor = AlignmentDirectional.center;
 
   ContextMenuState.submenu({
@@ -65,8 +77,10 @@ class ContextMenuState<T> extends ChangeNotifier {
     AlignmentGeometry? spawnAnchor,
     Rect? parentItemRect,
     this.onItemSelected,
+    bool requestFocus = true,
   })  : _spawnAnchor = spawnAnchor ?? AlignmentDirectional.topStart,
         _parentItemRect = parentItemRect,
+        _requestFocus = requestFocus,
         _isSubmenu = true;
 
   List<ContextMenuEntry> get entries => menu.entries;
@@ -166,6 +180,7 @@ class ContextMenuState<T> extends ChangeNotifier {
         selfClose: closeSubmenu,
         parentItem: parent,
         onItemSelected: onItemSelected,
+        requestFocus: _requestFocus,
       );
 
       return ContextMenuWidget<T>(menuState: subMenuState);
@@ -201,7 +216,9 @@ class ContextMenuState<T> extends ChangeNotifier {
 
       notifyListeners();
       _isPositionVerified = true;
-      focusScopeNode.requestFocus();
+      if (_requestFocus) {
+        focusScopeNode.requestFocus();
+      }
     });
   }
 

--- a/lib/src/widgets/context_menu_widget.dart
+++ b/lib/src/widgets/context_menu_widget.dart
@@ -40,7 +40,7 @@ class ContextMenuWidget<T> extends StatelessWidget {
                 bindings: defaultMenuShortcuts(context, state)
                   ..addAll(state.shortcuts),
                 child: FocusScope(
-                  autofocus: true,
+                  autofocus: state.requestFocus,
                   node: state.focusScopeNode,
                   child: Opacity(
                     opacity: state.isPositionVerified ? 1.0 : 0.0,

--- a/lib/src/widgets/menu_entry_widget.dart
+++ b/lib/src/widgets/menu_entry_widget.dart
@@ -122,7 +122,9 @@ class _MenuEntryWidgetState<T> extends State<MenuEntryWidget<T>> {
 
   void _ensureFocused(
       ContextMenuEntry entry, ContextMenuState menuState, FocusNode focusNode) {
-    menuState.focusScopeNode.requestFocus(focusNode);
+    if (menuState.requestFocus) {
+      menuState.focusScopeNode.requestFocus(focusNode);
+    }
     menuState.setFocusedEntry(entry);
   }
 }


### PR DESCRIPTION
When the context menu is opened via right-click or long press through ContextMenuRegion, it no longer requests focus. This preserves the visual text selection highlight in TextField/SelectableText widgets.

Previously, focus was unconditionally taken in three places:
- PageRouteBuilder with default requestFocus (true)
- FocusScope with autofocus: true
- focusScopeNode.requestFocus() in verifyPosition()

Now, a requestFocus flag propagates from the trigger source through the entire chain (route, widget, state, and submenus). Pointer-triggered menus default to requestFocus: false, while programmatic calls via showContextMenu() or ContextMenu.show() retain the existing behavior.

The fix also adds copyWith() to MenuRouteOptions for ergonomic use.